### PR TITLE
Use semaphore to wait for the initlization of memory hook functions

### DIFF
--- a/AddressMap.h
+++ b/AddressMap.h
@@ -85,7 +85,7 @@ public:
     {
         int index;
         if (hasAddr(addr, 0, _size - 1, &index)) {
-            for (int i = index; i < _size - 1; i++)
+            for (size_t i = index; i < _size - 1; i++)
                 _map[i] = _map[i+1];
             _size--;
         }

--- a/smtest.cpp
+++ b/smtest.cpp
@@ -46,6 +46,26 @@ thread_start(void *arg)
     return uargv;
 }
 
+class A {
+public:
+    A() {
+        a = malloc(10);
+        b = calloc(20, 100);
+    }
+    ~A() {
+        if (a)
+            free(a);
+        if (b)
+            free(b);
+    }
+
+private:
+    void* a;
+    void* b;
+};
+
+static A a;
+
 int
 main(int argc, char *argv[])
 {


### PR DESCRIPTION
malloc_hook maybe called in each memory hook functions(malloc, calloc, realoc, ...) and
**attribute**((constructor)) functions.
use semaphore to wait for the initization of memory hook functions in maloc_hook().

**attribute**((constructor)) is before **static_initialization_and_destruction_0
__attribute**((distructor)) is after __static_initialization_and_destruction_0

this Fixes #1
